### PR TITLE
Fix #22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-webview-interface",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Nativescript plugin for bi-directional communication between webView and android/ios.",
   "main": "index",
   "typings": "index.d.ts",


### PR DESCRIPTION
Makes nativescript-webview-interface compatible with NativeScript 3.4+ while not breaking support for older versions.